### PR TITLE
match table formatting to python's

### DIFF
--- a/src/rust-cli/network.rs
+++ b/src/rust-cli/network.rs
@@ -2,7 +2,7 @@ use anyhow::{bail, Context};
 use base64::{engine::general_purpose, Engine as _};
 use clap::Subcommand;
 use jsonrpsee::core::params::ObjectParams;
-use prettytable::{cell, Row, Table};
+use prettytable::{cell, format::consts::FORMAT_BOX_CHARS, Row, Table};
 use serde_json::Value;
 use std::path::PathBuf;
 
@@ -59,6 +59,7 @@ fn handle_network_start_response(data: serde_json::Value) -> anyhow::Result<()> 
     // warnet table
     if let Some(warnet_headers) = data["warnet_headers"].as_array() {
         let mut table = Table::new();
+        table.set_format(*FORMAT_BOX_CHARS);
         let headers: Vec<_> = warnet_headers
             .iter()
             .map(|header| header.as_str().unwrap_or(""))
@@ -88,6 +89,7 @@ fn handle_network_start_response(data: serde_json::Value) -> anyhow::Result<()> 
     // tanks table
     if let Some(tank_headers) = data["tank_headers"].as_array() {
         let mut table = Table::new();
+        table.set_format(*FORMAT_BOX_CHARS);
         let headers: Vec<_> = tank_headers
             .iter()
             .map(|header| header.as_str().unwrap_or(""))

--- a/src/rust-cli/scenarios.rs
+++ b/src/rust-cli/scenarios.rs
@@ -3,7 +3,7 @@ use anyhow::{bail, Context};
 use base64::{engine::general_purpose, Engine as _};
 use clap::Subcommand;
 use jsonrpsee::core::params::ObjectParams;
-use prettytable::{row, Table};
+use prettytable::{format::consts::FORMAT_BOX_CHARS, row, Table};
 use std::path::PathBuf;
 
 #[derive(Subcommand, Debug)]
@@ -38,6 +38,7 @@ async fn handle_available(params: ObjectParams) -> anyhow::Result<()> {
         .context("Making RPC to fetch available scenarios")?;
     if let serde_json::Value::Array(scenarios) = data {
         let mut table = Table::new();
+        table.set_format(*FORMAT_BOX_CHARS);
         table.add_row(row!["Scenario", "Description"]);
         for scenario in scenarios {
             if let serde_json::Value::Array(details) = scenario {
@@ -99,6 +100,7 @@ async fn handle_active(params: ObjectParams) -> anyhow::Result<()> {
         .context("Making RPC call to list running scenarios")?;
     if let serde_json::Value::Array(scenarios) = data {
         let mut table = Table::new();
+        table.set_format(*FORMAT_BOX_CHARS);
         table.add_row(row!["PID", "Command", "Network", "Active"]);
         for scenario in scenarios {
             if let serde_json::Value::Object(details) = scenario {


### PR DESCRIPTION
Change the table formatting so that it looks more similar to the python output. The smooth lines vs dashes may look similar with just a single cell, but on a larger grid the dashes have more visual noise.

```
┌──────────┐
│ Temp dir │
└──────────┘
```
vs
```
+-----------+
| Temp dir  |
+-----------+
```