### PR TITLE
upgrade dev image use and generated images

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           file: src/templates/rpc/Dockerfile_rpc
           context: .
-          tags: local/warnet-rpc:ci
+          tags: warnet/dev
           cache-from: type=gha
           cache-to: type=gha,mode=max
           outputs: type=docker,dest=/tmp/warnet.tar

--- a/justfile
+++ b/justfile
@@ -21,6 +21,10 @@ start:
 
     minikube start --mount --mount-string="$PWD:/mnt/src"
 
+    # Build image in local registry and load into minikube
+    docker build -t warnet/dev -f src/templates/rpc/Dockerfile_rpc_dev . --load
+    minikube image load warnet/dev
+
     # Setup k8s
     kubectl apply -f src/templates/rpc/namespace.yaml
     kubectl apply -f src/templates/rpc/rbac-config.yaml

--- a/src/templates/rpc/Dockerfile_rpc
+++ b/src/templates/rpc/Dockerfile_rpc
@@ -1,17 +1,25 @@
 # Use an official Python runtime as the base image
-FROM python:3.11-slim
+FROM python:3.12-slim
 
 # Install procps, which includes pgrep
 RUN apt-get update && \
     apt-get install -y procps openssh-client && \
     rm -rf /var/lib/apt/lists/*
 
+# Install `uv` packge installer (https://github.com/astral-sh/uv)
+RUN pip install uv
+
 # Set the working directory in the container
 WORKDIR /root/warnet
 
+# Get better caching by installing before copying code
+COPY requirements.txt .
+RUN uv pip install --system --no-cache -r requirements.txt
+
 # Copy the source directory contents into the container
 COPY . /root/warnet
-RUN pip install .
+# Install Warnet scripts
+RUN uv pip install --system .
 
 # Make port 9276 available to the world outside this container
 # Change the port if your server is running on a different port

--- a/src/templates/rpc/Dockerfile_rpc_dev
+++ b/src/templates/rpc/Dockerfile_rpc_dev
@@ -1,10 +1,13 @@
 # Use an official Python runtime as the base image
-FROM python:3.11-slim
+FROM python:3.12-slim
 
 # Install procps, which includes pgrep
 RUN apt-get update && \
     apt-get install -y procps openssh-client && \
     rm -rf /var/lib/apt/lists/*
+
+# Install `uv` packge installer (https://github.com/astral-sh/uv)
+RUN pip install uv
 
 # Set the working directory in the container
 WORKDIR /root/warnet

--- a/src/templates/rpc/entrypoint.sh
+++ b/src/templates/rpc/entrypoint.sh
@@ -31,7 +31,7 @@ done
 if check_setup_toml; then
     echo "Installing package from ${SOURCE_DIR}..."
     cd ${SOURCE_DIR}
-    pip install -e .
+    uv pip install --system --no-cache -e .
 fi
 
 # Execute the CMD from the Dockerfile

--- a/src/templates/rpc/warnet-rpc-statefulset-dev.yaml
+++ b/src/templates/rpc/warnet-rpc-statefulset-dev.yaml
@@ -16,8 +16,8 @@ spec:
     spec:
       containers:
       - name: warnet-rpc
-        imagePullPolicy: Always
-        image: bitcoindevproject/warnet-rpc:dev
+        imagePullPolicy: Never
+        image: warnet/dev
         ports:
         - containerPort: 9276
         volumeMounts:


### PR DESCRIPTION
1. Previously we were pulling the latest dev image from dockerhub@bitcoindevproject (not necessarily the image current! Nor might it be the PR changes...). We can easily create the image locally and load it into minikube at startup, so do that.

    This means the dev image can still benefit from caching on the host registry.

1. Upgrade the images to use `uv`. This provides semi-significant build speedups, but is also a better tool all around IMO.

1. This PR also is opened to re-check the CI is working from `on: pull_request`